### PR TITLE
PHP 7.2 compatibility fix

### DIFF
--- a/Compiler.php
+++ b/Compiler.php
@@ -1031,7 +1031,7 @@ class Compiler
         }
 
         //Add the path were currently compiling in (e.g. include, extends)
-        if (count($this->files) > 0)
+        if (is_array($this->files) && count($this->files) > 0)
             $paths[] = dirname(end($this->files));
 
         //Iterate paths and check file existence via realpath


### PR DESCRIPTION
Fix for

    count(): Parameter must be an array or an object that implements Countable

I'd like a tag/release if/when this gets merged as I depend on tale-jade/tale-pug in production. Thanks!

Not ready to upgrade to the new phug thing just yet.